### PR TITLE
feat: install lvm2 package in our kind image node

### DIFF
--- a/.github/workflows/build-kind-image.yaml
+++ b/.github/workflows/build-kind-image.yaml
@@ -38,6 +38,17 @@ jobs:
       - name: Build KinD image for ${{ matrix.arch }}
         run: |
           kind build node-image . --arch ${{ matrix.arch }} --image ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }}
+      - name: Repackage kind node with additional packages
+        run: |
+          cat <<EOF >>Dockerfile
+          FROM --platform=${{ matrix.arch }} ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }}
+
+          RUN sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+          RUN apt-get update && apt-get install -y lvm2 dpkg-dev && rm -rf /var/lib/apt/lists/*
+          EOF
+
+          cat Dockerfile
+          docker build -t ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }} -f Dockerfile .
       - name: Push KinD images
         run: |
           docker push ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }}

--- a/.github/workflows/build-kind-image.yaml
+++ b/.github/workflows/build-kind-image.yaml
@@ -44,7 +44,7 @@ jobs:
           FROM --platform=${{ matrix.arch }} ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }}
 
           RUN sed -i -e 's/archive.ubuntu.com\|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
-          RUN apt-get update && apt-get install -y lvm2 dpkg-dev && rm -rf /var/lib/apt/lists/*
+          RUN apt-get update && apt-get install -y lvm2 && rm -rf /var/lib/apt/lists/*
           EOF
 
           cat Dockerfile


### PR DESCRIPTION
This PR installs `lvm2` package by default on our kind image nodes. This makes it easy to use lvm binary in airgapped kind clusters.

This change creates an ephemeral Dockerfile with extends `FROM` the docker image built by the GH action and then installs `lvm2` package in that image without mutating the ENTRYPOINT. I tested this manually by doing  `docker build ..` first and then used that image to `kind create --image ..` a cluster. The cluster came up just fine with no hiccups.