### PR TITLE
ci: Single quote heredoc to prevent command not found

### DIFF
--- a/.github/workflows/build-kind-image.yaml
+++ b/.github/workflows/build-kind-image.yaml
@@ -40,7 +40,7 @@ jobs:
           kind build node-image . --arch ${{ matrix.arch }} --image ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }}
       - name: Repackage kind node with additional packages
         run: |
-          cat <<EOF >>Dockerfile
+          cat <<'EOF' >>Dockerfile
           FROM --platform=${{ matrix.arch }} ${{ github.repository_owner }}/kind-node:${{ github.event.inputs.tag }}-${{ matrix.arch }}
 
           # If the base image used (e.g.: https://github.com/kubernetes-sigs/kind/blob/v0.16.0/pkg/build/nodeimage/defaults.go#L23) in KinD ever gets outdated, move to `old-release.ubuntu.com`


### PR DESCRIPTION
Seen in CI:

```
/home/runner/work/_temp/f8173f78-b048-41a2-8221-f17fd0932d5c.sh: line 1:
old-release.ubuntu.com: command not found
```

By single quoting the heredoc the backticked command will not run and thus prevent seeing this output in GHA logs.