### PR TITLE
Revert "ci: Use latest kind-action"

### DIFF
--- a/.github/workflows/build-kind-image.yaml
+++ b/.github/workflows/build-kind-image.yaml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.inputs.tag }}
       - name: Install KinD
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@v1.3.0
         with:
           install_only: true
       - name: Login to Docker Hub


### PR DESCRIPTION
This reverts commit 35d71816f82c1d96794b20ab1be61674d03ef934.

KIND version v0.15.0 broke something where in TC when building the Konvoy bootstrap image external domains do not get resolved. Reverting back to an older version of the github action that defaulted to kind v0.14.0.