### PR TITLE
fix: use KIND version v0.20.0

### DIFF
--- a/.github/workflows/build-kind-image.yaml
+++ b/.github/workflows/build-kind-image.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: helm/kind-action@v1.8.0
         with:
           install_only: true
-          version: v0.19.0
+          version: v0.20.0
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
KIND v0.20.0 requires the Node images to be built with v0.20.0 https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0

I [built v1.27.4 with these changes](https://github.com/mesosphere/kind-docker-image-automation/actions/runs/5799820909) and tested it in [Konvoy](https://github.com/mesosphere/konvoy2/actions/runs/5800179389/job/15721724376?pr=2217) where [it was failing before](https://github.com/mesosphere/konvoy2/actions/runs/5799673287/job/15720169682).


I also tested using this image with DKP 2.6/2.5/2.4 and it all worked, meaning we can use this version of KIND to build all images even for older versions of DKP.

 