### PR TITLE
ci: Only build >=1.27 and prevent unnecssary rebuilds of 1.3x images

### DIFF
--- a/.github/workflows/k8s-repo-tag-sync.yaml
+++ b/.github/workflows/k8s-repo-tag-sync.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "tags=$(
             gh api --cache 0s --paginate /repos/${{ github.repository }}/tags | \
-              jq -r 'map(select(.name | test("^v1.2[2-9].[0-9]+$")))[].name' | \
+              jq -r 'map(select(.name | test("^v1.(2[7-9]|[3-9][0-9]).[0-9]+$")))[].name' | \
               tr '\n' ' '
           )" >> $GITHUB_OUTPUT
         env:
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo "tags=$(
             gh api --cache 0s --paginate /repos/${{ github.repository }}/tags | \
-              jq -r 'map(select(.name | test("^v1.(2[2-9]|[3-9][0-9]).[0-9]+$")))[].name' | \
+              jq -r 'map(select(.name | test("^v1.(2[7-9]|[3-9][0-9]).[0-9]+$")))[].name' | \
               tr '\n' ' '
           )" >> $GITHUB_OUTPUT
         env:


### PR DESCRIPTION
Noticed that 1.3x images were always being unnecessarily rebuilt
due to dodgy image tag regex.

Also no need to build images for anything older than 1.27 patch releases.
